### PR TITLE
Add better instructions for fixing PRs

### DIFF
--- a/main.go
+++ b/main.go
@@ -113,7 +113,20 @@ https://github.com/docker/docker/blob/master/CONTRIBUTING.md#sign-your-work
 
 The easiest way to do this is to amend the last commit:
 
-` + "`git commit --amend -s --no-edit && git push -f`"
+~~~console
+`
+		comment += fmt.Sprintf("$ git clone -b %q %s %s\n", pr.Head.Ref, pr.Head.Repo.SSHURL, "somewhere")
+		comment += fmt.Sprintf("$ cd %s\n", "somewhere")
+		if pr.Commits > 1 {
+			comment += fmt.Sprintf("$ git rebase -i HEAD~%d\n", pr.Commits)
+			comment += "editor opens\nchange each 'pick' to 'edit'\nsave the file and quit\n"
+		}
+		comment += "$ git commit --amend -s --no-edit\n"
+		if pr.Commits > 1 {
+			comment += "$ git rebase --continue # and repeat the amend for each commit\n"
+		}
+		comment += "$ git push -f\n"
+		comment += `~~~`
 
 		if _, err := gh.AddComment(repo, strconv.Itoa(prHook.Number), comment); err != nil {
 			return err


### PR DESCRIPTION
Here's an example of what this _should_ create: (for a PR with only one commit)

~~~console
$ git clone -b "wut-fix" git@github.com/tianon/my-fork.git somewhere
$ cd somewhere
$ git commit --amend -s --no-edit
$ git push -f
~~~

If a PR has more than one commit (like, say, 5), we'll get something more like:

~~~console
$ git clone -b "wut-big-fix" git@github.com/tianon/my-fork.git somewhere
$ cd somewhere
$ git rebase -i HEAD~5
editor opens
change each 'pick' to 'edit'
save the file and quit
$ git commit --amend -s --no-edit
$ git rebase --continue # and repeat the amend for each commit
$ git push -f
~~~

Fixes #1